### PR TITLE
avoid yarn warning on running different node binary

### DIFF
--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -21,4 +21,6 @@ RUN adduser -D -u 1337 developer && deluser --remove-home node
 COPY entrypoint /entrypoint
 RUN chmod +x /entrypoint
 
+RUN npm config set scripts-prepend-node-path true
+
 ENTRYPOINT [ "/entrypoint" ]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,4 +21,6 @@ RUN adduser -D -u 1337 developer && deluser --remove-home node
 COPY entrypoint /entrypoint
 RUN chmod +x /entrypoint
 
+RUN npm config set scripts-prepend-node-path true
+
 ENTRYPOINT [ "/entrypoint" ]


### PR DESCRIPTION
Avoid warning on running scripts with yarn that then execute npm.

https://github.com/yarnpkg/yarn/issues/6617

